### PR TITLE
refactor: centralize storage logic into storage.py; decouple routes from OUTPUT/UPLOAD dirs

### DIFF
--- a/server/routes/generate.py
+++ b/server/routes/generate.py
@@ -1,17 +1,12 @@
 # routes/generate.py
 
-import os
 from starlette.responses import JSONResponse
-from services.storage import persist_image
+from services.storage import persist_output_image, load_upload_image
 from services.inference import run_inference_image, run_inference_edit
 from services.models import ensure_mode
-from config import ASPECT_RATIOS, UPLOADS_DIR
-from PIL import Image
+from config import ASPECT_RATIOS
 
 async def generate_image(request):
-    """
-    Handle text-to-image generation with Qwen-Image.
-    """
     data = await request.json()
     try:
         ensure_mode(request.app, "image")
@@ -24,7 +19,7 @@ async def generate_image(request):
             cfg=float(data.get("cfg", 1.0)),
             steps=int(data.get("steps", 4)),
         )
-        uid, _ = persist_image(image)
+        uid, _ = persist_output_image(image)
     except ValueError as e:
         return JSONResponse({"error": str(e), "allowed": list(ASPECT_RATIOS.keys())}, status_code=400)
     except Exception as e:
@@ -36,26 +31,16 @@ async def generate_image(request):
     })
 
 
-
 async def generate_edit(request):
-    """
-    Handle image-to-image editing with Qwen-Image-Edit.
-    """
     data = await request.json()
     try:
         if "input_id" not in data:
             return JSONResponse({"error": "Missing required field: input_id"}, status_code=400)
 
-        # Resolve uploaded image by uid
-        uid_in = data["input_id"]
-        filepath = os.path.join(UPLOADS_DIR, f"{uid_in}.png")
-        if not os.path.exists(filepath):
+        input_image = load_upload_image(data["input_id"])
+        if not input_image:
             return JSONResponse({"error": "Input image not found"}, status_code=404)
 
-        # input_image = Image.open(filepath).convert("RGB")
-        with Image.open(filepath) as im:
-            input_image = im.convert("RGB")
-            
         ensure_mode(request.app, "edit")
         image = run_inference_edit(
             pipe=request.app.state.pipe,
@@ -64,7 +49,7 @@ async def generate_edit(request):
             input_image=input_image,
             steps=int(data.get("steps", 4)),
         )
-        uid, _ = persist_image(image)
+        uid, _ = persist_output_image(image)
 
     except Exception as e:
         return JSONResponse({"error": f"inference failed: {e}"}, status_code=500)

--- a/server/routes/images.py
+++ b/server/routes/images.py
@@ -1,48 +1,27 @@
 # routes/images.py
 
-import os
-import uuid
 from starlette.responses import JSONResponse, FileResponse
-from config import OUTPUT_DIR, UPLOADS_DIR
-
+from services import storage
 
 async def fetch_image(request):
     uid = request.path_params["uid"]
-    filepath = os.path.join(OUTPUT_DIR, f"{uid}.png")
-    if not os.path.exists(filepath):
+    filepath = storage.fetch_output_path(uid)
+    if not filepath:
         return JSONResponse({"error": "not found"}, status_code=404)
     return FileResponse(filepath)
-
 
 async def fetch_upload(request):
-    """
-    Fetch an uploaded image by UID from UPLOADS_DIR.
-    """
     uid = request.path_params["uid"]
-    filepath = os.path.join(UPLOADS_DIR, f"{uid}.png")
-    if not os.path.exists(filepath):
+    filepath = storage.fetch_upload_path(uid)
+    if not filepath:
         return JSONResponse({"error": "not found"}, status_code=404)
     return FileResponse(filepath)
 
-
 async def upload_image(request):
-    """
-    Handle image uploads. Accepts multipart/form-data with a file field.
-    Stores the image in UPLOADS_DIR and returns a UID.
-    """
     form = await request.form()
     if "file" not in form:
         return JSONResponse({"error": "Missing 'file' in upload"}, status_code=400)
 
     file = form["file"]
-    uid = str(uuid.uuid4())
-    filepath = os.path.join(UPLOADS_DIR, f"{uid}.png")
-
-    # Save file to disk
-    with open(filepath, "wb") as f:
-        f.write(await file.read())
-
-    return JSONResponse({
-        "id": uid,
-        "message": "Image uploaded successfully"
-    })
+    uid, _ = storage.save_upload_bytes(await file.read())
+    return JSONResponse({"id": uid, "message": "Image uploaded successfully"})

--- a/server/services/storage.py
+++ b/server/services/storage.py
@@ -1,14 +1,43 @@
-# services/storage.py
 import os, uuid
-from config import OUTPUT_DIR
+from config import OUTPUT_DIR, UPLOADS_DIR
+from PIL import Image
 
-def persist_image(image):
-    """
-    Save a PIL image and return (uid, filepath).
-    Currently uses local filesystem as storage.
-    """
+def _make_path(base_dir: str, uid: str) -> str:
+    return os.path.join(base_dir, f"{uid}.png")
+
+# --- Output (generated images) ---
+
+def persist_output_image(image: Image.Image):
+    """Save a generated image into OUTPUT_DIR and return its uid + path."""
     uid = uuid.uuid4().hex
-    filename = f"{uid}.png"
-    filepath = os.path.join(OUTPUT_DIR, filename)
+    filepath = _make_path(OUTPUT_DIR, uid)
     image.save(filepath)
     return uid, filepath
+
+def fetch_output_path(uid: str):
+    """Return path of a generated image if it exists, else None."""
+    filepath = _make_path(OUTPUT_DIR, uid)
+    return filepath if os.path.exists(filepath) else None
+
+# --- Uploads (user uploads) ---
+
+def save_upload_bytes(data: bytes):
+    """Save uploaded raw bytes into UPLOADS_DIR and return uid + path."""
+    uid = uuid.uuid4().hex
+    filepath = _make_path(UPLOADS_DIR, uid)
+    with open(filepath, "wb") as f:
+        f.write(data)
+    return uid, filepath
+
+def fetch_upload_path(uid: str):
+    """Return path of an uploaded image if it exists, else None."""
+    filepath = _make_path(UPLOADS_DIR, uid)
+    return filepath if os.path.exists(filepath) else None
+
+def load_upload_image(uid: str):
+    """Open an uploaded image as PIL.Image, or None if missing."""
+    filepath = fetch_upload_path(uid)
+    if not filepath:
+        return None
+    with Image.open(filepath) as im:
+        return im.convert("RGB")


### PR DESCRIPTION
- routes/generate.py hands over control over storage information to services/storage.py
- routes/images.py hands over control over storage information to services/storage.py