### PR TITLE
feat: add MODE toggle and bucket fetch support to rust client 

### DIFF
--- a/client/src/consts.rs
+++ b/client/src/consts.rs
@@ -53,3 +53,9 @@ pub(crate) const PATH_UPLOAD:         &str = "upload/";
 pub(crate) fn join_base(base: &str, path: &str) -> String {
     if base.ends_with('/') { format!("{base}{path}") } else { format!("{base}/{path}") }
 }
+
+
+// mode
+pub(crate) fn server_mode() -> String {
+    get_var("MODE").unwrap_or_else(|| "local".to_string())
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -27,8 +27,10 @@ async fn main() -> std::io::Result<()> {
     let image_base         = consts::server_image();
     let upload_image_base  = consts::server_image_upload();
     let upload_base        = consts::server_upload();
+    let mode               = consts::server_mode(); // <-- NEW
 
     println!("🚀 Actix server running at: http://{}:{}/", host, port);
+    println!("⚙️  MODE         {}", mode); // <-- NEW
     println!("🔗 {:<12} {}", "route",        server_route);
     for (backend, url) in [
         ("gen_image",    gen_image_base.as_str()),

--- a/client/src/routes/image.rs
+++ b/client/src/routes/image.rs
@@ -8,6 +8,7 @@ use crate::consts::{
     PATH_IMAGE, PATH_UPLOAD,
     join_base,
     server_image, server_upload,
+    server_mode,
 };
 
 async fn fetch_image(
@@ -15,8 +16,17 @@ async fn fetch_image(
     client: web::Data<Client>,
 ) -> impl Responder {
     let uid = path.into_inner();
-    let base = server_image();
-    let url = join_base(&base, &format!("{PATH_IMAGE}{uid}"));
+    let mode = server_mode();
+
+    let url = if mode == "buck3t" {
+        // direct to bucket using SERVER_IMAGE as base
+        let base = server_image(); 
+        format!("{}objects/output/{uid}.png?download=0", base)
+    } else {
+        // local → unchanged
+        let base = server_image();
+        join_base(&base, &format!("{PATH_IMAGE}{uid}"))
+    };
 
     match client.get(url).send().await {
         Ok(resp) => {


### PR DESCRIPTION
- this allows for the distribution of load across multiple systems and is the precursor to completely distributed workloads
- system is incomplete, quite a bit to refactor but one can already run qwen-image-edit and qwen-image from two diff machines feeding one buck3t.
- documentation will be needed 