### PR TITLE
feat(gateway): buck3t-aware uploads & image recall with startup-mode routing

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,6 +8,8 @@ actix-web = "*"
 actix-files = "*"
 serde = { version = "*", features = ["derive"] }
 reqwest = { version = "*", features = ["json", "multipart"] }
-
 dotenvy = "*"
 serde_json = "1"
+uuid = { version = "1.18.0", features = ["v4"] }
+actix-multipart = "*"
+futures-util = "*"

--- a/client/src/routes/image.rs
+++ b/client/src/routes/image.rs
@@ -11,22 +11,26 @@ use crate::consts::{
     server_mode,
 };
 
-async fn fetch_image(
+// ---------- helpers ----------
+
+fn pass_through_ct_or_default(resp: &reqwest::Response, default_ct: &str) -> String {
+    resp.headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(default_ct)
+        .to_string()
+}
+
+// ---------- /image/{uid} ----------
+
+// LOCAL → proxy to python image server
+async fn fetch_image_local(
     path: web::Path<String>,
     client: web::Data<Client>,
 ) -> impl Responder {
     let uid = path.into_inner();
-    let mode = server_mode();
-
-    let url = if mode == "buck3t" {
-        // direct to bucket using SERVER_IMAGE as base
-        let base = server_image(); 
-        format!("{}objects/output/{uid}.png?download=0", base)
-    } else {
-        // local → unchanged
-        let base = server_image();
-        join_base(&base, &format!("{PATH_IMAGE}{uid}"))
-    };
+    let base = server_image();
+    let url = join_base(&base, &format!("{PATH_IMAGE}{uid}"));
 
     match client.get(url).send().await {
         Ok(resp) => {
@@ -35,8 +39,9 @@ async fn fetch_image(
                     .unwrap_or(ActixStatusCode::INTERNAL_SERVER_ERROR);
                 return HttpResponse::build(status).body("Backend returned error");
             }
+            let ct = pass_through_ct_or_default(&resp, "image/png");
             match resp.bytes().await {
-                Ok(bytes) => HttpResponse::Ok().content_type("image/png").body(bytes),
+                Ok(bytes) => HttpResponse::Ok().content_type(ct).body(bytes),
                 Err(e) => HttpResponse::InternalServerError().body(format!("Error reading image bytes: {e}")),
             }
         }
@@ -44,7 +49,36 @@ async fn fetch_image(
     }
 }
 
-async fn fetch_upload(
+// BUCK3T → direct to bucket: /objects/output/{uid}.png?download=0
+async fn fetch_image_buck3t(
+    path: web::Path<String>,
+    client: web::Data<Client>,
+) -> impl Responder {
+    let uid = path.into_inner();
+    let base = server_image();
+    let url = format!("{}objects/output/{uid}.png?download=0", base);
+
+    match client.get(url).send().await {
+        Ok(resp) => {
+            if !resp.status().is_success() {
+                let status = ActixStatusCode::from_u16(resp.status().as_u16())
+                    .unwrap_or(ActixStatusCode::INTERNAL_SERVER_ERROR);
+                return HttpResponse::build(status).body("Backend returned error");
+            }
+            let ct = pass_through_ct_or_default(&resp, "image/png");
+            match resp.bytes().await {
+                Ok(bytes) => HttpResponse::Ok().content_type(ct).body(bytes),
+                Err(e) => HttpResponse::InternalServerError().body(format!("Error reading image bytes: {e}")),
+            }
+        }
+        Err(e) => HttpResponse::InternalServerError().body(format!("Request failed: {e}")),
+    }
+}
+
+// ---------- /upload/{uid} ----------
+
+// LOCAL → proxy to python upload server
+async fn fetch_upload_local(
     path: web::Path<String>,
     client: web::Data<Client>,
 ) -> impl Responder {
@@ -59,8 +93,9 @@ async fn fetch_upload(
                     .unwrap_or(ActixStatusCode::INTERNAL_SERVER_ERROR);
                 return HttpResponse::build(status).body("Backend returned error");
             }
+            let ct = pass_through_ct_or_default(&resp, "image/png");
             match resp.bytes().await {
-                Ok(bytes) => HttpResponse::Ok().content_type("image/png").body(bytes),
+                Ok(bytes) => HttpResponse::Ok().content_type(ct).body(bytes),
                 Err(e) => HttpResponse::InternalServerError().body(format!("Error reading upload bytes: {e}")),
             }
         }
@@ -68,7 +103,40 @@ async fn fetch_upload(
     }
 }
 
+// BUCK3T → direct to bucket: /objects/uploads/{uid}.png?download=0
+async fn fetch_upload_buck3t(
+    path: web::Path<String>,
+    client: web::Data<Client>,
+) -> impl Responder {
+    let uid = path.into_inner();
+    let base = server_image(); // same base as other buck3t calls
+    let url = format!("{}objects/uploads/{uid}.png?download=0", base);
+
+    match client.get(url).send().await {
+        Ok(resp) => {
+            if !resp.status().is_success() {
+                let status = ActixStatusCode::from_u16(resp.status().as_u16())
+                    .unwrap_or(ActixStatusCode::INTERNAL_SERVER_ERROR);
+                return HttpResponse::build(status).body("Backend returned error");
+            }
+            let ct = pass_through_ct_or_default(&resp, "image/png");
+            match resp.bytes().await {
+                Ok(bytes) => HttpResponse::Ok().content_type(ct).body(bytes),
+                Err(e) => HttpResponse::InternalServerError().body(format!("Error reading upload bytes: {e}")),
+            }
+        }
+        Err(e) => HttpResponse::InternalServerError().body(format!("Request failed: {e}")),
+    }
+}
+
+// ---------- init ----------
+// Choose handlers at startup based on SERVER_MODE
 pub(crate) fn init(cfg: &mut web::ServiceConfig) {
-    cfg.route("/image/{uid}", web::get().to(fetch_image))
-       .route("/upload/{uid}", web::get().to(fetch_upload));
+    if server_mode() == "buck3t" {
+        cfg.route("/image/{uid}", web::get().to(fetch_image_buck3t))
+          .route("/upload/{uid}", web::get().to(fetch_upload_buck3t));
+    } else {
+        cfg.route("/image/{uid}", web::get().to(fetch_image_local))
+          .route("/upload/{uid}", web::get().to(fetch_upload_local));
+    }
 }

--- a/client/src/routes/upload.rs
+++ b/client/src/routes/upload.rs
@@ -2,11 +2,19 @@
 
 use actix_web::{web, HttpResponse, Responder, HttpRequest};
 use actix_web::http::StatusCode as ActixStatusCode;
+use actix_multipart::Multipart;
+use futures_util::StreamExt; // for .next()
 use reqwest::Client;
+use uuid::Uuid;
 
-use crate::consts::{PATH_IMAGE_UPLOAD, join_base, server_image_upload};
+use crate::consts::{
+    PATH_IMAGE_UPLOAD, join_base, server_image_upload,
+    server_mode, server_image,
+};
 
-async fn upload_image(
+// ---------- PROXY (local/python) ----------
+// forwards request body as-is to the Python backend
+async fn upload_image_proxy(
     req: HttpRequest,
     payload: web::Bytes,
     client: web::Data<Client>,
@@ -32,6 +40,94 @@ async fn upload_image(
     }
 }
 
+// ---------- BUCK3T (direct) ----------
+// consumes multipart, takes the "file" part, uploads to buck3t as /objects/uploads/{uid}.png
+async fn upload_image_buck3t(
+    mut mp: Multipart,
+    client: web::Data<Client>,
+) -> impl Responder {
+    // find the "file" field
+    let mut found = false;
+    let mut file_bytes = web::BytesMut::new();
+    let mut content_type_hdr: Option<String> = None;
+
+    while let Some(item) = mp.next().await {
+        let mut field = match item {
+            Ok(f) => f,
+            Err(e) => return HttpResponse::BadRequest().body(format!("Malformed multipart: {e}")),
+        };
+
+        // We only care about the "file" field, ignore others
+        if field.name() != Some("file") {
+            // drain this field to move on
+            while let Some(chunk) = field.next().await {
+                if chunk.is_err() { break; }
+            }
+            continue;
+        }
+
+        // mime from the part if present (fall back later)
+        if let Some(mt) = field.content_type() {
+            content_type_hdr = Some(mt.to_string());
+        }
+
+        found = true;
+        while let Some(chunk) = field.next().await {
+            match chunk {
+                Ok(bytes) => file_bytes.extend_from_slice(&bytes),
+                Err(e) => return HttpResponse::BadRequest().body(format!("Error reading file data: {e}")),
+            }
+        }
+        break; // only first "file"
+    }
+
+    if !found {
+        return HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "Missing 'file' in upload"
+        }));
+    }
+
+    // generate hex uid (like Python's uuid4().hex)
+    let uid = Uuid::new_v4().simple().to_string();
+
+    // build buck3t object URL (same base used in image.rs for buck3t)
+    // e.g. {base}objects/uploads/{uid}.png
+    let base = server_image();
+    let url = format!("{}objects/uploads/{}.png", base, uid);
+
+    // content-type: honor part or default
+    let ct = content_type_hdr.unwrap_or_else(|| "application/octet-stream".to_string());
+
+    // PUT to buck3t
+    let put = client
+        .put(url)
+        .header("content-type", ct)
+        .body(file_bytes.freeze())
+        .send()
+        .await;
+
+    match put {
+        Ok(resp) if resp.status().is_success() => {
+            HttpResponse::Ok().json(serde_json::json!({
+                "id": uid,
+                "message": "Image uploaded successfully"
+            }))
+        }
+        Ok(resp) => {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            HttpResponse::BadGateway().body(format!("buck3t PUT failed: {status} {text}"))
+        }
+        Err(e) => HttpResponse::BadGateway().body(format!("buck3t PUT error: {e}")),
+    }
+}
+
+// ---------- init ----------
+// Choose handler at startup based on SERVER_MODE
 pub(crate) fn init(cfg: &mut web::ServiceConfig) {
-    cfg.route("/image/upload", web::post().to(upload_image));
+    if server_mode() == "buck3t" {
+        cfg.route("/image/upload", web::post().to(upload_image_buck3t));
+    } else {
+        cfg.route("/image/upload", web::post().to(upload_image_proxy));
+    }
 }


### PR DESCRIPTION
## Summary
Add **buck3t** support to the rust client:

- Direct upload to buck3t on `POST /image/upload` (multipart)
- Direct recall from buck3t on `GET /image/{uid}` and `GET /upload/{uid}`
- Local mode still proxies to Python unchanged
- Handlers are selected at startup via `server_mode()` (no runtime branching)

## Why
- Remove double hops and simplify the hot path in **buck3t** deployments
- Keep local development identical to today
- Prepare for future multi-distributed routing by decoupling gateway behavior from a single backend


## Deps
```toml
uuid = { version = "1.18.0", features = ["v4"] } # generate hex IDs compatible with Python’s uuid4().hex
actix-multipart = "*"                           # parse multipart uploads
futures-util = "*"                              # StreamExt for reading multipart chunks
