### PR TITLE
feat: python backend server now supports loading multiple loras 

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -28,8 +28,9 @@ GGUF_MODELS = {
 MODE = os.environ["MODE"]  # required
 MODEL_ID = AVAILABLE_MODELS[MODE]
 
-# Shared LoRA path (works for both)
-LORA_PATH = os.environ["QWEN_LORA_PATH"]
+# LoRA config straight from env
+LORA_PATH   = os.environ["QWEN_LORA_PATH"]
+LORA_SELECT = os.environ["QWEN_LORA_SELECT"]
 
 # Output directory (fake S3 bucket for now)
 OUTPUT_DIR = os.environ["OUTPUT_DIR"]

--- a/server/core/factory.py
+++ b/server/core/factory.py
@@ -7,6 +7,9 @@ from routes import health_check
 from routes.generate import generate_image, generate_edit
 from routes.images import fetch_image, upload_image, fetch_upload
 from services.models import build_pipe_auto
+from services.lora_manager import list_available_loras
+from pprint import pprint
+
 
 def create_app():
     app = Starlette(debug=True, routes=[
@@ -24,5 +27,8 @@ def create_app():
         active_key = next((k for k, v in AVAILABLE_MODELS.items() if v == MODEL_ID), None)
         app.state.pipe = build_pipe_auto(active_key)
         app.state.active_key = active_key
+
+        print("[LoRA] available (from lora_manager):")
+        pprint(list_available_loras())
 
     return app

--- a/server/services/inference.py
+++ b/server/services/inference.py
@@ -1,7 +1,25 @@
 # /services/inference.py
-
 import torch
+import pprint
 from config import ASPECT_RATIOS, DEVICE
+
+
+def _log_inference_call(name: str, kwargs: dict):
+    """
+    Utility to pretty-print inference call metadata.
+    """
+    print(f"[inference] {name} called with:")
+    for k, v in kwargs.items():
+        if isinstance(v, torch.Tensor):
+            print(f"  {k}: Tensor(shape={tuple(v.shape)}, dtype={v.dtype}, device={v.device})")
+        elif hasattr(v, "size") and hasattr(v, "mode"):  # crude check for PIL.Image
+            print(f"  {k}: PIL.Image(size={v.size}, mode={v.mode})")
+        else:
+            try:
+                # safe pretty format
+                print(f"  {k}: {pprint.pformat(v)}")
+            except Exception:
+                print(f"  {k}: {type(v)}")
 
 
 def run_inference_image(pipe, prompt, negative_prompt, seed, aspect_ratio, cfg, steps=4):
@@ -13,6 +31,19 @@ def run_inference_image(pipe, prompt, negative_prompt, seed, aspect_ratio, cfg, 
 
     width, height = ASPECT_RATIOS[aspect_ratio]
     generator = torch.Generator(device=DEVICE).manual_seed(seed)
+
+    args = dict(
+        prompt=prompt,
+        negative_prompt=negative_prompt,
+        seed=seed,
+        aspect_ratio=aspect_ratio,
+        width=width,
+        height=height,
+        cfg=cfg,
+        steps=steps,
+        device=DEVICE,
+    )
+    _log_inference_call("run_inference_image", args)
 
     image = pipe(
         prompt=prompt,
@@ -32,6 +63,15 @@ def run_inference_edit(pipe, prompt, seed, input_image, steps=4):
     Run inference for Qwen-Image-Edit (image-to-image).
     """
     generator = torch.Generator(device=DEVICE).manual_seed(seed)
+
+    args = dict(
+        prompt=prompt,
+        seed=seed,
+        steps=steps,
+        device=DEVICE,
+        input_image=input_image,
+    )
+    _log_inference_call("run_inference_edit", args)
 
     image = pipe(
         image=input_image,

--- a/server/services/lora_manager.py
+++ b/server/services/lora_manager.py
@@ -1,0 +1,69 @@
+# services/lora_manager.py
+
+from pathlib import Path
+from typing import Optional
+from pprint import pprint
+from config import LORA_PATH as _LORA_PATH, LORA_SELECT as _LORA_SELECT
+
+
+def list_available(root: str) -> list[str]:
+    p = Path(root)
+    if p.is_file():
+        return [p.name]
+    if p.is_dir():
+        return sorted(f.name for f in p.glob("*.safetensors"))
+    return []
+
+def list_available_loras() -> list[str]:
+    return list_available(_LORA_PATH)
+
+
+def validate_selection(root: str, selected_name: Optional[str]) -> Optional[Path]:
+    if not selected_name:
+        return None
+
+    root_path = Path(root)
+    if not root_path.exists():
+        raise FileNotFoundError(f"[LoRA] root path not found: {root}")
+
+    if root_path.is_file():
+        if selected_name == root_path.name:
+            return root_path
+        raise FileNotFoundError(
+            f"[LoRA] selection '{selected_name}' does not match single file '{root_path.name}'"
+        )
+
+    fp = root_path / selected_name
+    if not fp.exists():
+        raise FileNotFoundError(
+            f"[LoRA] '{selected_name}' not found in {root}. Available: {list_available(root)}"
+        )
+    return fp
+
+
+def load_from_spec(pipe, root: str, selected_name: Optional[str]) -> None:
+    path = validate_selection(root, selected_name)
+    if path is None:
+        return
+    print("[LoRA] loading:")
+    pprint(str(path))
+    pipe.load_lora_weights(str(path))
+
+
+def load_lora(pipe) -> None:
+    """
+    Load selected LoRA(s) into `pipe` using values from config.
+    """
+    print("[LoRA] config values:")
+    pprint({"LORA_PATH": _LORA_PATH, "LORA_SELECT": _LORA_SELECT})
+
+    if not _LORA_SELECT:
+        return
+
+    # split by commas and trim whitespace
+    selections = [s.strip() for s in _LORA_SELECT.split(",") if s.strip()]
+    for sel in selections:
+        path = validate_selection(_LORA_PATH, sel)
+        print("[LoRA] loading:")
+        pprint(str(path))
+        pipe.load_lora_weights(str(path))

--- a/server/services/models.py
+++ b/server/services/models.py
@@ -2,7 +2,8 @@
 import gc, torch
 import torch.nn as nn
 from diffusers import AutoModel, DiffusionPipeline, QwenImageTransformer2DModel, GGUFQuantizationConfig
-from config import LORA_PATH, TORCH_DTYPE, QUANT_CONFIG, AVAILABLE_MODELS, GGUF_MODELS, USE_GGUF
+from config import TORCH_DTYPE, QUANT_CONFIG, AVAILABLE_MODELS, GGUF_MODELS, USE_GGUF
+from services.lora_manager import load_lora
 
 def _gb(x):
     return f"{(x/(1024**3)):.2f} GB"
@@ -112,7 +113,7 @@ def build_pipe(model_id: str):
         transformer=transformer,
         torch_dtype=TORCH_DTYPE,
     )
-    pipe.load_lora_weights(LORA_PATH)
+    load_lora(pipe)
     pipe.enable_model_cpu_offload()
     return pipe
 
@@ -130,7 +131,7 @@ def build_pipe_gguf(model_id: str, gguf_path: str):
         transformer=transformer,   # override!
         torch_dtype=torch.bfloat16,
     )
-    pipe.load_lora_weights(LORA_PATH)
+    load_lora(pipe)
     pipe.enable_model_cpu_offload()
     return pipe
 


### PR DESCRIPTION
- services/lora_manager.py allows for the loading of multiple loras at once
- config.py now loads the base lora path and is 'aware' of the selected loras. will need to make this into an app.state to allows users to adjust while live. 
- services/models.py now uses load_lora from services/lora_manager.py allowing for multi lora configs
- better logging through out the app. though, need to make a toggle system.